### PR TITLE
Fixed relative path in examples

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -86,7 +86,7 @@
     </div>
     
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
-    <script src="jquery.stopwatch.js"></script>
+    <script src="../jquery.stopwatch.js"></script>
     <script>
         $(document).ready(function() {
             $('#demo1').stopwatch().stopwatch('start');


### PR DESCRIPTION
If you open the `example/index.html` file the `jquery.stopwatch.js` script will not load since it is located one level above. 

This pull request tries to fix that.
