### PR TITLE
Fix bug when using pugin with multiple elements

### DIFF
--- a/jquery.stopwatch.js
+++ b/jquery.stopwatch.js
@@ -47,7 +47,6 @@
             };
             
             // if (options) { $.extend(settings, options); }
-            var settings = $.extend({}, defaults, options);
             
             return this.each(function() {
                 var $this = $(this),
@@ -56,6 +55,7 @@
                 // If the plugin hasn't been initialized yet
                 if (!data) {
                     // Setup the stopwatch data
+                    var settings = $.extend({}, defaults, options);
                     data = settings;
                     data.active = false;
                     data.target = $this;


### PR DESCRIPTION
Hi,

I've been using your plugin and I found out that when you set up the stopwatch on several elements it ends up using the last one. Look at this: http://jsfiddle.net/pablogd/PhFqR/

This pull request solves the issue, so check it and if you want merge it. Thanks for this great plugin! it's been really useful.

Cheers
