### PR TITLE
Use the system clock to determine elapsed time

### DIFF
--- a/jquery.stopwatch.js
+++ b/jquery.stopwatch.js
@@ -1,7 +1,20 @@
 (function( $ ){
 
     function incrementer(ct, increment) {
-        return function() { ct+=increment; return ct; };
+        var startDate = new Date();
+        var startCt = ct;
+        // Make sure we have an actual number for startCt
+        if (!startCt) {
+            startCt = 0;
+        }
+        var result = function() {
+            return startCt + Math.round((new Date() - startDate)/increment)*increment;
+        };
+        result.restart = function(newCt) {
+            startCt = newCt;
+            startDate = new Date();
+        }
+        return result;
     }
     
     function pad2(number) {
@@ -79,6 +92,9 @@
                 var $this = $(this),
                     data = $this.data('stopwatch');
                 // Mark as active
+                if(!data.active) {
+                    data.incrementer.restart(data.elapsed);
+                }
                 data.active = true;
                 data.timerID = setInterval(data.tick_function, data.updateInterval);
                 $this.data('stopwatch', data);

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,34 @@ test("Stop", function(){
     equals($elem.data('stopwatch').active, false);
 });
 
+test("Stop and then Start", function(){
+    var interval = $elem.data('stopwatch').updateInterval;
+    // Start the stopwatch for one tick, stop it for more than two ticks, then
+    // restart it for one more tick.  The elapsed time should be two ticks, even
+    // though three and a half ticks worth of actual wall clock time went by.
+    var firstTick = true;
+    var restart = function() {
+        // in-between waiting time is over; restart the stopwatch
+        $elem.stopwatch('start');
+    }
+    $elem.stopwatch().bind('tick.stopwatch', function(e, elapsed) {
+        if (firstTick) {
+            // First tick: stop and wait 2.5 ticks
+            equals($elem.stopwatch('getTime'), interval);
+            $elem.stopwatch('stop');
+            setTimeout(restart, Math.floor(interval*2.5));
+        } else {
+            // Second tick: stop the stopwatch, elapsed should be 2 ticks
+            equals($elem.stopwatch('getTime'), interval * 2);
+            $elem.stopwatch('stop');
+            start();
+        }
+        firstTick = false;
+    });
+    stop();
+    $elem.stopwatch('start');
+});
+
 test("Toggle", function(){
     $elem.stopwatch('stop');
     $elem.stopwatch('toggle');


### PR DESCRIPTION
Hi Rob,

I created a patch to make it use the system clock, rather than relying on receiving every interval, to determine the elapsed time.  This allows it to show the true elapsed time even if it missed (or duplicated) some of its timer events, which should make it more accurate.

The main reason I did this was for use on Android and iOS.  On iOS, if I go back to the home screen or switch to a different browser tab, the page stops receiving javascript timer events.  On Android it manages to send events while in the background, but only until the screen goes to sleep.  With the code as it stands, the stopwatch won't advance when it's not receiving events, so you can't trust the time it shows if the page isn't constantly visible.  With my patch, it is able to catch up and display the true elapsed time, even if the device has gone to sleep in the middle.

I would also guess that this probably fixes the problem @Blacksus described in #6.  I don't know if it actually does fix it, because I never ran into the #6 problem myself.  But this patch would make it show an accurate elapsed time, even if the time between the interval events becomes weird.
